### PR TITLE
fix: Windows captions path + empty-description Director fallback

### DIFF
--- a/src/agents/director.py
+++ b/src/agents/director.py
@@ -170,10 +170,28 @@ A-Roll entries contribute to total_duration. When planning:
   are obviously strong from description and transcript alone.
 
 ## Workflow
-1. Read the brief and footage_index_path from the user message.
+1. Read the brief and footage_index_path from the user message. The user
+   message ALSO includes a `Shots inventory` block listing every shot in
+   the FootageIndex (source_file, start_time, end_time, transcript
+   snippet). Use this inventory as your source of truth — descriptions in
+   the FootageIndex may be empty, so `search_moments` can return nothing
+   even when shots exist.
+1a. If shots have empty or unhelpful descriptions/transcripts, you MUST
+   call `analyze_footage(video_path=<source_file>, brief=<brief JSON>)`
+   on EVERY unique source_file in the inventory before selecting clips.
+   This produces scene-by-scene descriptions, energy levels, and key
+   quotes that you need to make informed selections. Do not skip this
+   step when descriptions are empty — without it you cannot produce a
+   valid plan.
+1b. After analyze_footage, build EditPlanEntry items referencing the
+   ORIGINAL Shot.source_file and Shot.start_time from the inventory
+   (NOT the scene start_times from analyze_footage). Use start_trim and
+   end_trim to point to the sub-range within that shot that corresponds
+   to the analyze_footage scene you liked.
 2. For each narrative beat (hook, problem, solution, proof, CTA), call
    search_moments with a query that captures that beat. Use a
-   min_relevance around 0.2 and ask for 3 to 5 candidates per beat.
+   min_relevance around 0.0 (descriptions may be empty) and ask for 3 to
+   5 candidates per beat.
 3. Search for B-Roll candidates too: call search_moments with queries
    like "product", "texture", "application", "packaging", "close-up",
    "b-roll". Great ads use a mix of footage types.
@@ -487,6 +505,26 @@ def run_director(
     agent = build_director(brief)
     runner = InMemoryRunner(agent=agent, app_name=_APP_NAME)
 
+    # Load the FootageIndex and inline a Shots inventory into the user
+    # message so the Director can reason about clips even when shot
+    # descriptions are empty (preprocess does not always populate them).
+    from json import loads as _loads
+
+    fi_raw = Path(footage_index_path).read_text(encoding="utf-8")
+    fi_data = _loads(fi_raw)
+    inv_lines: list[str] = []
+    for s in fi_data.get("shots", []):
+        tr = (s.get("transcript") or "").strip().replace("\n", " ")
+        if len(tr) > 200:
+            tr = tr[:200] + "…"
+        inv_lines.append(
+            f"- source_file={s['source_file']} | start_time={s['start_time']} | "
+            f"end_time={s['end_time']} | roll_type={s.get('roll_type','unknown')} | "
+            f"description={s.get('description','') or '(empty)'} | "
+            f"transcript_snippet={tr or '(empty)'}"
+        )
+    inventory = "\n".join(inv_lines) if inv_lines else "(no shots)"
+
     user_message = genai_types.Content(
         role="user",
         parts=[
@@ -496,7 +534,11 @@ def run_director(
                     f"Brief JSON: {brief.model_dump_json()}\n\n"
                     f"Footage index path (use this exact path in tool "
                     f"calls): {footage_index_path}\n\n"
-                    "Produce the EditPlan now."
+                    f"Shots inventory ({len(inv_lines)} shots):\n"
+                    f"{inventory}\n\n"
+                    "If descriptions/transcripts above are empty, call "
+                    "analyze_footage on each unique source_file BEFORE "
+                    "selecting clips. Produce the EditPlan now."
                 )
             )
         ],

--- a/src/tools/captions.py
+++ b/src/tools/captions.py
@@ -230,20 +230,30 @@ def burn_ass_subtitles(video: str, subtitles: str, output: str) -> str:
     output_path = Path(output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    subtitle_path = str(Path(subtitles).resolve()).replace("\\", r"\\").replace(":", r"\:")
+    # Windows: ffmpeg's ass filter mis-parses backslashes and drive-letter
+    # colons. Run with cwd=subtitle's parent dir and pass just the filename.
+    sub_resolved = Path(subtitles).resolve()
+    video_resolved = Path(video).resolve()
+    out_resolved = output_path.resolve()
     cmd = [
         "ffmpeg",
         "-y",
         "-i",
-        video,
+        str(video_resolved),
         "-vf",
-        f"ass={subtitle_path}",
+        f"ass={sub_resolved.name}",
         "-c:a",
         "copy",
-        str(output_path),
+        str(out_resolved),
     ]
     try:
-        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=str(sub_resolved.parent),
+        )
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(f"FFmpeg failed: {exc.stderr}") from exc
     return str(output_path)


### PR DESCRIPTION
## Summary

Two independent fixes I hit running the CLI on real footage:

1. **`src/tools/captions.py`** — `burn_ass_subtitles` is unusable on Windows because ffmpeg's `ass` filter mis-parses the drive-letter colon and backslashes in absolute paths. Workaround: run ffmpeg with `cwd=` set to the subtitle's parent dir and pass only the filename to the filter. Works identically on POSIX.

2. **`src/agents/director.py`** — when `Shot.description` is empty across the FootageIndex (which is the default — the bundled preprocessor only fills scene boundaries + Whisper transcripts), `search_moments` returns no candidates above the 0.2 default threshold. The Director then silently emits an `EditPlan` with 0 entries, which crashes the Editor with `EditPlan has zero entries; nothing to render`. Two adjustments:
   - `run_director` now inlines a full shots inventory (source_file, start/end, roll_type, description, transcript snippet) into the user message so the Director sees clips that are invisible to lexical search.
   - `DIRECTOR_INSTRUCTION` instructs the agent to call `analyze_footage` on every unique source_file when descriptions are empty, and lowers the recommended `min_relevance` from 0.2 to 0.0.

After both fixes the pipeline runs through to a rendered MP4 on a fresh footage set with no manual prep.

## Test plan

- [x] Repro on Windows with two GoPro clips and an empty-description FootageIndex — pipeline previously aborted at the Editor with `zero entries` / `Invalid argument`; with this PR it produces `output/final/<name>.mp4`.
- [ ] POSIX regression — `burn_ass_subtitles` still works with the new `cwd=` approach (no functional change to the filter string on POSIX, just a different working directory).
- [ ] Director regression on a FootageIndex that already has populated descriptions — extra inventory in the user message should be additive, not destructive.

## Notes

Tested against `google-adk==2.0.0` and `gemini-2.5-pro` (current `>=1.0.0` pin + `gemini-3.1-pro-preview` default both refused to run on my account — separate issue, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)